### PR TITLE
Track simplification

### DIFF
--- a/gpxsimplify/main.go
+++ b/gpxsimplify/main.go
@@ -1,0 +1,55 @@
+// Copyright 2016 Florian Pigorsch. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ptrv/go-gpx"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Println("Usage: gpxsimplify [-dist DIST] INPUTFILE OUTPUTFILE")
+		flag.PrintDefaults()
+	}
+
+	maxDist := flag.Float64("dist", 5, "Max distance (in meters) for track simplification. Must be >= 0.")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) != 2 {
+		fmt.Println("Error: You must specify both INPUTFILE and OUTPUTFILE")
+		flag.Usage()
+		return
+	} else if *maxDist < 0 {
+		fmt.Println("Error: -dist must be >= 0")
+		flag.Usage()
+		return
+	}
+
+	gpxFile, err := gpx.ParseFile(args[0])
+	if err != nil {
+		fmt.Println("Error reading input GPX file:", err)
+		return
+	}
+
+	gpxFile.SimplifyTracks(*maxDist)
+
+	f, err := os.Create(args[1])
+	if err != nil {
+		fmt.Println("Error creating output GPX file:", err)
+		return
+	}
+	defer f.Close()
+
+	_, err = f.Write(gpxFile.ToXML())
+	if err != nil {
+		fmt.Println("Error writing output GPX file:", err)
+		return
+	}
+}


### PR DESCRIPTION
This PR adds track simplification using the [Ramer-Douglas-Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) simpliar to the implementation used in gpxpy.

The main function is `func (g *Gpx) SimplifyTracks(maxDist float64) {...}`.

I have also added an example program `gpxsimplify` that reads a GPX file, applies track simplification (configurable via the `-dist` command line option), and writes the results to a new GPX file.
